### PR TITLE
Add glibc support in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:latest
+
+# Install glibc using sgerrand's package repository
+RUN apk add --no-cache wget ca-certificates \
+    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+    && GLIBC_VERSION=2.37-r0 \
+    && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
+    && apk add --no-cache glibc-${GLIBC_VERSION}.apk \
+    && rm glibc-${GLIBC_VERSION}.apk

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,8 @@
 {
-  "name": "vanilla-alpine",
-  "image": "alpine:latest"
+  "name": "alpine-glibc",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  }
 }
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # devcontainer-test
+
+This repository uses an Alpine-based devcontainer with glibc installed.
+


### PR DESCRIPTION
## Summary
- create a Dockerfile for the Alpine devcontainer and install glibc
- update devcontainer configuration to build from Dockerfile
- document the change in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847720a9c088332b283d798cd7d95e4